### PR TITLE
MANTA-5506 Fix buckets-mdapi template and default port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 #
 # Copyright 2020 Joyent, Inc.
 # Copyright 2023 MNX Cloud, Inc.
+# Copyright 2026 Edgecast Cloud LLC.
 #
 
 NAME = manta-buckets-mdapi
@@ -48,7 +49,7 @@ manta-scripts: deps/manta-scripts/.git
 	cp deps/manta-scripts/*.sh $(BUILD)/scripts
 
 .PHONY: release
-release: all deps docs $(SMF_MANIFESTS)
+release: all deps docs $(SMF_MANIFESTS) sapi_manifests/registrar/template
 	@echo "Building $(RELEASE_TARBALL)"
 	@mkdir -p $(RELSTAGEDIR)/root/opt/smartdc/buckets-mdapi/deps
 	@mkdir -p $(RELSTAGEDIR)/root/opt/smartdc/buckets-mdapi/bin

--- a/sapi_manifests/registrar/template.in
+++ b/sapi_manifests/registrar/template.in
@@ -5,9 +5,9 @@
     "service": {
       "type": "service",
       "service": {
-        "srvce": "_buckets_mdapi",
+        "srvce": "_buckets-mdapi",
         "proto": "_tcp",
-        "port": 2020
+        "port": 2030
       },
       "ttl": 60
     },


### PR DESCRIPTION
I encountered this issue while attempting to get Manta Rebalancer to discover MDAPI nodes. This change fixes two problems:

- The srvce name that gets registered into zookeeper does not comply with the REGEX used in binder when clients query records of type SRV or ANY resulting in a REFUSED response from binder.

- The default port for mdapi is 2030 and not 2020

Testing notes in the ticket.